### PR TITLE
Allen initail commit

### DIFF
--- a/Misc/restore env.R
+++ b/Misc/restore env.R
@@ -1,0 +1,11 @@
+library(renv)
+
+Sys.setenv(RENV_DOWNLOAD_FILE_METHOD = "libcurl")
+options(repos = c(CRAN = "https://cloud.r-project.org"))
+
+renv::restore(
+  # clean = TRUE
+  # , 
+  confirm = FALSE, 
+  repos = "https://cloud.r-project.org"
+)

--- a/Model/data simulate.R
+++ b/Model/data simulate.R
@@ -1,0 +1,60 @@
+library(dplyr)
+#' @title simulate data simple
+#' @param n_pols number of policies
+#' @param Intercept_lambda poisson rate
+#' @param Intercept_mu  lognormal mu
+#' @param b_lambda betas for lamda
+#' @param b_mu   betas for mu
+#' @param sigma  lognormal sigma
+#' @param deductibles   deductibles amount
+#' @export
+data_sim_simple <- function(n_pols, Intercept_lambda, Intercept_mu, b_lambda, b_mu, sigma, deductibles) {
+  
+  pol_df <- tibble::tibble(
+    pol_id = seq_len(n_pols), 
+    freq_lvl = sample(seq_len(length(b_lambda)), size = n_pols, replace = T), 
+    mu_lvl = sample(seq_len(length(b_mu)), size = n_pols, replace = T), 
+    ded = sample(deductibles, size = n_pols, replace = T)
+  ) %>% 
+    dplyr::mutate(
+      freq_factor = b_lambda[freq_lvl] + Intercept_lambda, 
+      mu_factor = b_mu[mu_lvl] + Intercept_mu, 
+      claim_fgu = rpois(dplyr::n(), lambda = freq_factor)
+    )
+  
+  sev_df <- pol_df %>% 
+    dplyr::filter(claim_fgu > 0) %>% 
+    dplyr::group_nest(pol_id) %>% 
+    dplyr::mutate(
+      claim_id = purrr::map(data, ~seq_len(.$claim_fgu)),
+      loss = purrr::map(data, ~rlnorm(.$claim_fgu, .$mu_factor, sigma))
+    ) %>% 
+    tidyr::unnest(cols = c(data, claim_id, loss)) %>% 
+    dplyr::filter(loss > ded) %>% 
+    dplyr::mutate(
+      freq2 = 0, 
+      claim_id = paste0(pol_id, "_", claim_id), 
+      claimcount = 0
+    )
+  
+   frq_df <- pol_df %>% 
+     dplyr::select(pol_id, freq_lvl, mu_lvl, ded) %>% 
+     dplyr::left_join(
+       sev_df %>% dplyr::group_by(pol_id) %>% dplyr::summarise(claimcount = dplyr::n())
+     ) %>% 
+     dplyr::mutate(
+       claimcount = dplyr::coalesce(claimcount, 0), 
+       freq2 = 1, 
+       loss = ded + 0.1, 
+       claim_id = '0'
+     )
+   
+   return(
+     dplyr::bind_rows(
+       frq_df, sev_df %>% dplyr::select(-freq_factor, -mu_factor, -claim_fgu)
+     ) %>% 
+       dplyr::mutate_at(
+         dplyr::vars(dplyr::ends_with('lvl')), as.character
+       )
+   )
+}

--- a/Model/frq vs sev model v2.R
+++ b/Model/frq vs sev model v2.R
@@ -1,0 +1,34 @@
+library(dplyr)
+library(brms)
+
+
+source('model/data simulate.R')
+set.seed(12345)
+full_data <- data_sim_simple(n_pols = 5000, Intercept_lambda = 0.5, Intercept_mu = 8, 
+                             b_lambda = c(0, 0.2), b_mu = c(0, -1, 1), sigma = 2, 
+                             deductibles = c(0, 5e3, 10e3, 25e3, 5e4))
+
+fit_freq = 
+  bf(claimcount ~ f1 + freq2 * 0 ,
+     f1 ~ freq_lvl,
+     nl = TRUE) + 
+  poisson()
+
+fit_sev = 
+  bf(loss | trunc(lb = ded) ~ mu_lvl) + 
+  lognormal()
+
+stan_data <- brms::make_standata(
+  formula = fit_freq + fit_sev + set_rescor(FALSE),
+  data = full_data, 
+  prior = c(prior(normal(0, 2), class = 'b', coef = 'Intercept', resp = 'claimcount', nlpar = 'f1'))
+)
+
+library(rstan)
+options(mc.cores = parallel::detectCores())
+fit <- rstan::stan(file = 'Model/frq vs sev stancode v3.stan', 
+                   data = stan_data,
+                   chains = 4, iter = 2000, warmup = 1000, 
+                   cores = 4
+)
+fit

--- a/Model/frq vs sev stancode v3.stan
+++ b/Model/frq vs sev stancode v3.stan
@@ -1,0 +1,80 @@
+// generated with brms 2.15.0
+functions {
+    /* poisson lognormal composite lpdf 
+   * Args: 
+   *   y: the loss amount
+   *   y1: the claim count
+   *   mu: mean parameter of the lognormal distribution 
+   *   sigma: sd parameter of the lognormal distribution
+   *   lambda: the mean of the poisson distribution
+   * Returns:  
+   *   a scalar to be added to the log posterior 
+   */ 
+  real poisson_lognormal_lpdf(real y, int y1, real ded, real mu, real sigma, real lambda) {
+    if (y == 0) {
+      return poisson_lpmf(y1 | lambda * (1 - lognormal_cdf(ded, mu, sigma)));
+    } else {
+      return lognormal_lpdf(y | mu, sigma) - lognormal_lccdf(ded | mu, sigma);
+    }
+  }
+  
+}
+
+data {
+  int<lower=1> N;  // total number of observations
+  int<lower=1> N_claimcount;  // number of observations
+  int Y_claimcount[N_claimcount];   // response variable
+  int<lower=1> K_claimcount_f1;  // number of population-level effects
+  matrix[N_claimcount, K_claimcount_f1] X_claimcount_f1;  // population-level design matrix
+  // covariate vectors for non-linear functions
+  vector[N_claimcount] C_claimcount_1;
+  int<lower=1> N_loss;  // number of observations
+  vector[N_loss] Y_loss;  // response variable
+  real lb_loss[N];
+  int<lower=1> K_loss;  // number of population-level effects
+  matrix[N_loss, K_loss] X_loss;  // population-level design matrix
+  // covariate vectors for non-linear functions
+  int prior_only;  // should the likelihood be ignored?
+}
+transformed data {
+}
+parameters {
+  vector[K_claimcount_f1] b_claimcount_f1;  // population-level effects
+  vector[K_loss] b_loss;  // population-level effects
+  real<lower=0> sigma_loss;  // residual SD
+}
+transformed parameters {
+}
+model {
+  // likelihood including constants
+  if (!prior_only) {
+    // initialize linear predictor term
+    vector[N_claimcount] nlp_claimcount_f1 = X_claimcount_f1 * b_claimcount_f1;
+    // initialize non-linear predictor term
+    vector[N_claimcount] mu_claimcount;
+    // initialize linear predictor term
+    vector[N_loss] nlp_loss = X_loss * b_loss;
+    // initialize non-linear predictor term
+    vector[N_loss] mu_loss;
+    for (n in 1:N) {
+      // compute non-linear predictor values
+      mu_loss[n] = nlp_loss[n];
+      mu_claimcount[n] = nlp_claimcount_f1[n] + log(1 - lognormal_cdf(lb_loss[n], mu_loss[n], sigma_loss));
+    }
+    for (n in 1:N) {
+      if (C_claimcount_1[n] == 1) {
+        target += poisson_log_lpmf(Y_claimcount[n] | mu_claimcount[n]);
+      } else {
+          target += lognormal_lpdf(Y_loss[n] | mu_loss[n], sigma_loss) -
+        lognormal_lccdf(lb_loss[n] | mu_loss[n], sigma_loss);
+      }
+    }
+  }
+  // priors including constants
+  target += normal_lpdf(b_claimcount_f1 | 0, 1);
+  target += normal_lpdf(b_loss | 5, 2);
+  target += student_t_lpdf(sigma_loss | 3, 0, 3.9)
+    - 1 * student_t_lccdf(0 | 3, 0, 3.9);
+}
+generated quantities {
+}


### PR DESCRIPTION
restore env.R
To restore the renv might need to set the repo to be CRAN rather than MRAN

data simulate.R
create a function to simulate simple categorical variables for frequency and severity components

frq vs sev model v2.R
example model that work with different frequency and severity factors

frq vs sev stancode v3.stan
stan code that works with the current frq and severity data setup

I think this pull request should address issue #1 and #5 partially, since it would still rely on a pre-written .stan code. Will need to explore ways to modify the brms::make_stancode function to generate the stancode with conditional likelihood block automatically, and then potentially issue a pull request to the brms package.