### PR TITLE
MLE and sample_prior

### DIFF
--- a/02_Model/Frequency Severity BRMS.R
+++ b/02_Model/Frequency Severity BRMS.R
@@ -162,7 +162,7 @@ mv_model_fit =
     ),
     
     ded_name = "ded",
-    use_cmdstan = TRUE,
+    use_cmdstan = FALSE,
     
     chains = 2,
     
@@ -171,7 +171,9 @@ mv_model_fit =
 
     refresh = 100,
     adapt_delta = 0.999,
-    max_treedepth = 15
+    max_treedepth = 15,
+    
+    mle = TRUE
     
     # control =
     #   list(adapt_delta = 0.999,

--- a/02_Model/Frequency Severity BRMS.R
+++ b/02_Model/Frequency Severity BRMS.R
@@ -162,21 +162,20 @@ mv_model_fit =
     ),
     
     ded_name = "ded",
-    use_cmdstan = FALSE,
+    use_cmdstan = TRUE,
     
-    chains = 1,
-    parallel_chains = 4,
+    chains = 2,
     
     iter = 1000,
     warmup = 250,
 
     refresh = 100,
-    # adapt_delta = 0.999,
-    # max_treedepth = 15
+    adapt_delta = 0.999,
+    max_treedepth = 15
     
-    control =
-      list(adapt_delta = 0.999,
-           max_treedepth = 15)
+    # control =
+    #   list(adapt_delta = 0.999,
+    #        max_treedepth = 15)
   )
 
 #### Results ####

--- a/bayesact/R/brms_freq_sev.R
+++ b/bayesact/R/brms_freq_sev.R
@@ -233,6 +233,7 @@ brms_freq_sev =
     use_cmdstan  = FALSE,
     iter         = 1000,
     warmup       = 250,
+    sample_prior = "no",
     ...
   ){
 
@@ -729,7 +730,8 @@ brms_freq_sev =
         mv_model_formula,
         data = full_data,
         prior = priors,
-        stanvars = stanvars
+        stanvars = stanvars,
+        sample_prior = sample_prior
       )
 
     mv_model_data =
@@ -737,13 +739,15 @@ brms_freq_sev =
         mv_model_formula,
         data = full_data,
         prior = priors,
-        stanvars = stanvars
+        stanvars = stanvars,
+        sample_prior = sample_prior
       )
 
     mv_model_fit <-
       brm( formula = mv_model_formula,
            data = full_data,
            prior = priors,
+           sample_prior = sample_prior,
            empty = TRUE
       )
 


### PR DESCRIPTION
I have added the mle argument to the brms_freq_sev function, which calculates the MLE for the model instead of MCMC sampling. This is useful in the early stages of model development, as it allows you to determine whether the model structure is reasonable before doing a full Bayesian model fit.